### PR TITLE
Fix: Using set sometimes gets Helm provider confused

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ No Modules.
 | k8s\_service\_account\_name | The k8s cluster-autoscaler service account name | `string` | `"cluster-autoscaler"` | no |
 | mod\_dependency | Dependence variable binds all AWS resources allocated by this module, dependent modules reference this variable | `bool` | `null` | no |
 | settings | Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/cluster-autoscaler | `map(any)` | `{}` | no |
+| values | Additional **yaml encoded** values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/cluster-autoscaler" | `string` | `{}` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ No Modules.
 | k8s\_service\_account\_name | The k8s cluster-autoscaler service account name | `string` | `"cluster-autoscaler"` | no |
 | mod\_dependency | Dependence variable binds all AWS resources allocated by this module, dependent modules reference this variable | `bool` | `null` | no |
 | settings | Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/cluster-autoscaler | `map(any)` | `{}` | no |
-| values | Additional **yaml encoded** values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/cluster-autoscaler" | `string` | `{}` | no |
+| values | Additional **yaml encoded** values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/cluster-autoscaler" | `string` | `""` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ No Modules.
 | k8s\_service\_account\_name | The k8s cluster-autoscaler service account name | `string` | `"cluster-autoscaler"` | no |
 | mod\_dependency | Dependence variable binds all AWS resources allocated by this module, dependent modules reference this variable | `bool` | `null` | no |
 | settings | Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/cluster-autoscaler | `map(any)` | `{}` | no |
-| values | Additional **yaml encoded** values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/cluster-autoscaler" | `string` | `""` | no |
+| values | Additional yaml encoded values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/cluster-autoscaler" | `string` | `""` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ No Modules.
 | k8s\_service\_account\_name | The k8s cluster-autoscaler service account name | `string` | `"cluster-autoscaler"` | no |
 | mod\_dependency | Dependence variable binds all AWS resources allocated by this module, dependent modules reference this variable | `bool` | `null` | no |
 | settings | Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/cluster-autoscaler | `map(any)` | `{}` | no |
-| values | Additional yaml encoded values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/cluster-autoscaler" | `string` | `""` | no |
+| values | Additional yaml encoded values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/cluster-autoscaler | `string` | `""` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -9,41 +9,11 @@ resource "helm_release" "cluster_autoscaler" {
   version    = var.helm_chart_version
   repository = var.helm_repo_url
 
-  set {
-    name  = "awsRegion"
-    value = data.aws_region.current.name
-  }
-
-  set {
-    name  = "autoDiscovery.clusterName"
-    value = var.cluster_name
-  }
-
-  set {
-    name  = "rbac.create"
-    value = "true"
-  }
-
-  set {
-    name  = "rbac.serviceAccount.create"
-    value = "true"
-  }
-
-  set {
-    name  = "rbac.serviceAccount.name"
-    value = var.k8s_service_account_name
-  }
-
-  set {
-    name  = "rbac.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
-    value = aws_iam_role.cluster_autoscaler[0].arn
-  }
-
-  dynamic "set" {
-    for_each = var.settings
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
+  values     = [yamlencode({
+    "autoDiscovery.clusterName"                                  = var.cluster_name
+    "rbac.create"                                                = true
+    "rbac.serviceAccount.create"                                 = true
+    "rbac.serviceAccount.name"                                   = var.k8s_service_account_name
+    "rbac.serviceAccount.annotations.eks.amazonaws.com/role-arn" = var.k8s_service_account_name
+  }) ,var.values]
 }

--- a/main.tf
+++ b/main.tf
@@ -15,5 +15,5 @@ resource "helm_release" "cluster_autoscaler" {
     "rbac.serviceAccount.create"                                 = true
     "rbac.serviceAccount.name"                                   = var.k8s_service_account_name
     "rbac.serviceAccount.annotations.eks.amazonaws.com/role-arn" = var.k8s_service_account_name
-  }), yamlencode(var.values)]
+  }), var.values]
 }

--- a/main.tf
+++ b/main.tf
@@ -15,5 +15,5 @@ resource "helm_release" "cluster_autoscaler" {
     "rbac.serviceAccount.create"                                 = true
     "rbac.serviceAccount.name"                                   = var.k8s_service_account_name
     "rbac.serviceAccount.annotations.eks.amazonaws.com/role-arn" = var.k8s_service_account_name
-  }) ,var.values]
+  }), yamlencode(var.values)]
 }

--- a/main.tf
+++ b/main.tf
@@ -16,4 +16,12 @@ resource "helm_release" "cluster_autoscaler" {
     "rbac.serviceAccount.name"                                   = var.k8s_service_account_name
     "rbac.serviceAccount.annotations.eks.amazonaws.com/role-arn" = var.k8s_service_account_name
   }), var.values]
+
+  dynamic "set" {
+    for_each = var.settings
+    content {
+      name  = set.key
+      value = set.value
+    }
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -10,6 +10,7 @@ resource "helm_release" "cluster_autoscaler" {
   repository = var.helm_repo_url
 
   values     = [yamlencode({
+    "awsRegion"                                                  = data.aws_region.current.name
     "autoDiscovery.clusterName"                                  = var.cluster_name
     "rbac.create"                                                = true
     "rbac.serviceAccount.create"                                 = true

--- a/variables.tf
+++ b/variables.tf
@@ -70,6 +70,6 @@ variable "mod_dependency" {
 
 variable "values" {
   type        = string
-  default     = {}
-  description = "Additional values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/cluster-autoscaler"
+  default     = ""
+  description = "Additional yaml encoded values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/cluster-autoscaler"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -68,8 +68,8 @@ variable "mod_dependency" {
   description = "Dependence variable binds all AWS resources allocated by this module, dependent modules reference this variable"
 }
 
-variable "settings" {
-  type        = map(any)
+variable "values" {
+  type        = string
   default     = {}
-  description = "Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/cluster-autoscaler"
+  description = "Additional values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/cluster-autoscaler"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -68,6 +68,12 @@ variable "mod_dependency" {
   description = "Dependence variable binds all AWS resources allocated by this module, dependent modules reference this variable"
 }
 
+variable "settings" {
+  type        = map(any)
+  default     = {}
+  description = "Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/cluster-autoscaler"
+}
+
 variable "values" {
   type        = string
   default     = ""


### PR DESCRIPTION
There are several reports of unresolved issues when using the `set` block of helm provider, see: 
- https://github.com/hashicorp/terraform-provider-helm/issues/476 
- https://github.com/hashicorp/terraform-provider-helm/issues/711

I have encountered this issue when using this module as well and using `var.settings` to set values.  

When passing values via the `values` attribute of helm provider, these seem to go away.  
This PR adds the ability to do so, while keeping `settings` for backwards compatibility.  