### PR TITLE
Override or add configuration options in values input

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 env:
-  TERRAFORM_DOCS_VERSION: "v0.11.2"
+  TERRAFORM_DOCS_VERSION: "v0.15.0"
   TFLINT_VERSION: "v0.25.0"
   TFSEC_VERSION: "v0.39.6"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
 #    - id: terraform_tfsec
     - id: terraform_docs
       args:
-        - '--args=--hide providers --sort-by-required'
+        - '--args=--hide providers --sort-by required'
 
   - repo: git://github.com/pecigonzalo/pre-commit-terraform-vars
     rev: v1.0.0

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ No Modules.
 | helm\_release\_name | Helm release name | `string` | `"cluster-autoscaler"` | no |
 | helm\_repo\_url | Helm repository | `string` | `"https://kubernetes.github.io/autoscaler"` | no |
 | k8s\_namespace | The K8s namespace in which the node-problem-detector service account has been created | `string` | `"cluster-autoscaler"` | no |
+| k8s\_rbac\_create | Whether to create and use RBAC resources | `bool` | `true` | no |
+| k8s\_service\_account\_create | Whether to create Service Account | `bool` | `true` | no |
 | k8s\_service\_account\_name | The k8s cluster-autoscaler service account name | `string` | `"cluster-autoscaler"` | no |
 | settings | Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/cluster-autoscaler | `map(any)` | `{}` | no |
 | values | Additional yaml encoded values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/cluster-autoscaler | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ No Modules.
 | helm\_create\_namespace | Create the namespace if it does not yet exist | `bool` | `true` | no |
 | helm\_release\_name | Helm release name | `string` | `"cluster-autoscaler"` | no |
 | helm\_repo\_url | Helm repository | `string` | `"https://kubernetes.github.io/autoscaler"` | no |
+| k8s\_irsa\_role\_create | Whether to create IRSA role and annotate service account | `bool` | `true` | no |
 | k8s\_namespace | The K8s namespace in which the node-problem-detector service account has been created | `string` | `"cluster-autoscaler"` | no |
 | k8s\_rbac\_create | Whether to create and use RBAC resources | `bool` | `true` | no |
 | k8s\_service\_account\_create | Whether to create Service Account | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -34,51 +34,52 @@ See [Basic example](examples/basic/README.md) for further information.
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13 |
-| aws | >= 2.0 |
-| helm | >= 1.0 |
-| utils | >= 0.12.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 1.0 |
+| <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.12.0 |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) |
-| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
-| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
-| [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
-| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
-| [helm_release](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) |
-| [utils_deep_merge_yaml](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) |
+| Name | Type |
+|------|------|
+| [aws_iam_policy.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [helm_release.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [aws_iam_policy_document.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.cluster_autoscaler_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [utils_deep_merge_yaml.values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| cluster\_identity\_oidc\_issuer | The OIDC Identity issuer for the cluster | `string` | n/a | yes |
-| cluster\_identity\_oidc\_issuer\_arn | The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account | `string` | n/a | yes |
-| cluster\_name | The name of the cluster | `string` | n/a | yes |
-| enabled | Variable indicating whether deployment is enabled | `bool` | `true` | no |
-| helm\_chart\_name | Helm chart name to be installed | `string` | `"cluster-autoscaler"` | no |
-| helm\_chart\_version | Version of the Helm chart | `string` | `"9.10.3"` | no |
-| helm\_create\_namespace | Create the namespace if it does not yet exist | `bool` | `true` | no |
-| helm\_release\_name | Helm release name | `string` | `"cluster-autoscaler"` | no |
-| helm\_repo\_url | Helm repository | `string` | `"https://kubernetes.github.io/autoscaler"` | no |
-| k8s\_irsa\_role\_create | Whether to create IRSA role and annotate service account | `bool` | `true` | no |
-| k8s\_namespace | The K8s namespace in which the node-problem-detector service account has been created | `string` | `"cluster-autoscaler"` | no |
-| k8s\_rbac\_create | Whether to create and use RBAC resources | `bool` | `true` | no |
-| k8s\_service\_account\_create | Whether to create Service Account | `bool` | `true` | no |
-| k8s\_service\_account\_name | The k8s cluster-autoscaler service account name | `string` | `"cluster-autoscaler"` | no |
-| settings | Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/cluster-autoscaler | `map(any)` | `{}` | no |
-| values | Additional yaml encoded values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/cluster-autoscaler | `string` | `""` | no |
+| <a name="input_cluster_identity_oidc_issuer"></a> [cluster\_identity\_oidc\_issuer](#input\_cluster\_identity\_oidc\_issuer) | The OIDC Identity issuer for the cluster | `string` | n/a | yes |
+| <a name="input_cluster_identity_oidc_issuer_arn"></a> [cluster\_identity\_oidc\_issuer\_arn](#input\_cluster\_identity\_oidc\_issuer\_arn) | The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster | `string` | n/a | yes |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Variable indicating whether deployment is enabled | `bool` | `true` | no |
+| <a name="input_helm_chart_name"></a> [helm\_chart\_name](#input\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"cluster-autoscaler"` | no |
+| <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"9.10.3"` | no |
+| <a name="input_helm_create_namespace"></a> [helm\_create\_namespace](#input\_helm\_create\_namespace) | Create the namespace if it does not yet exist | `bool` | `true` | no |
+| <a name="input_helm_release_name"></a> [helm\_release\_name](#input\_helm\_release\_name) | Helm release name | `string` | `"cluster-autoscaler"` | no |
+| <a name="input_helm_repo_url"></a> [helm\_repo\_url](#input\_helm\_repo\_url) | Helm repository | `string` | `"https://kubernetes.github.io/autoscaler"` | no |
+| <a name="input_k8s_irsa_role_create"></a> [k8s\_irsa\_role\_create](#input\_k8s\_irsa\_role\_create) | Whether to create IRSA role and annotate service account | `bool` | `true` | no |
+| <a name="input_k8s_namespace"></a> [k8s\_namespace](#input\_k8s\_namespace) | The K8s namespace in which the node-problem-detector service account has been created | `string` | `"cluster-autoscaler"` | no |
+| <a name="input_k8s_rbac_create"></a> [k8s\_rbac\_create](#input\_k8s\_rbac\_create) | Whether to create and use RBAC resources | `bool` | `true` | no |
+| <a name="input_k8s_service_account_create"></a> [k8s\_service\_account\_create](#input\_k8s\_service\_account\_create) | Whether to create Service Account | `bool` | `true` | no |
+| <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | The k8s cluster-autoscaler service account name | `string` | `"cluster-autoscaler"` | no |
+| <a name="input_settings"></a> [settings](#input\_settings) | Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/cluster-autoscaler | `map(any)` | `{}` | no |
+| <a name="input_values"></a> [values](#input\_values) | Additional yaml encoded values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/cluster-autoscaler | `string` | `""` | no |
 
 ## Outputs
 
-No output.
+No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Contributing and reporting issues

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See [Basic example](examples/basic/README.md) for further information.
 | terraform | >= 0.13 |
 | aws | >= 2.0 |
 | helm | >= 1.0 |
-| kubernetes | >= 1.10 |
+| utils | >= 0.12.0 |
 
 ## Modules
 
@@ -53,7 +53,7 @@ No Modules.
 | [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) |
 | [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
 | [helm_release](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) |
-| [kubernetes_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) |
+| [utils_deep_merge_yaml](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) |
 
 ## Inputs
 
@@ -64,12 +64,12 @@ No Modules.
 | cluster\_name | The name of the cluster | `string` | n/a | yes |
 | enabled | Variable indicating whether deployment is enabled | `bool` | `true` | no |
 | helm\_chart\_name | Helm chart name to be installed | `string` | `"cluster-autoscaler"` | no |
-| helm\_chart\_version | Version of the Helm chart | `string` | `"9.7.0"` | no |
+| helm\_chart\_version | Version of the Helm chart | `string` | `"9.10.3"` | no |
+| helm\_create\_namespace | Create the namespace if it does not yet exist | `bool` | `true` | no |
 | helm\_release\_name | Helm release name | `string` | `"cluster-autoscaler"` | no |
 | helm\_repo\_url | Helm repository | `string` | `"https://kubernetes.github.io/autoscaler"` | no |
 | k8s\_namespace | The K8s namespace in which the node-problem-detector service account has been created | `string` | `"cluster-autoscaler"` | no |
 | k8s\_service\_account\_name | The k8s cluster-autoscaler service account name | `string` | `"cluster-autoscaler"` | no |
-| mod\_dependency | Dependence variable binds all AWS resources allocated by this module, dependent modules reference this variable | `bool` | `null` | no |
 | settings | Additional settings which will be passed to the Helm chart values, see https://hub.helm.sh/charts/stable/cluster-autoscaler | `map(any)` | `{}` | no |
 | values | Additional yaml encoded values which will be passed to the Helm chart, see https://hub.helm.sh/charts/stable/cluster-autoscaler | `string` | `""` | no |
 

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -11,23 +11,23 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| cluster_autoscaler | ../../ |  |
-| eks_cluster | cloudposse/eks-cluster/aws |  |
-| eks_workers | cloudposse/eks-workers/aws |  |
-| vpc | terraform-aws-modules/vpc/aws |  |
+| <a name="module_cluster_autoscaler"></a> [cluster\_autoscaler](#module\_cluster\_autoscaler) | ../../ | n/a |
+| <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | 0.43.2 |
+| <a name="module_eks_node_group"></a> [eks\_node\_group](#module\_eks\_node\_group) | cloudposse/eks-node-group/aws | 0.25.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 3.6.0 |
 
 ## Resources
 
-| Name |
-|------|
-| [aws_eks_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) |
-| [aws_eks_cluster_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) |
+| Name | Type |
+|------|------|
+| [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
+| [aws_eks_cluster_auth.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
 
 ## Inputs
 
-No input.
+No inputs.
 
 ## Outputs
 
-No output.
+No outputs.
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,5 +1,6 @@
 module "vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "3.6.0"
 
   name               = "cluster-autoscaler-vpc"
   cidr               = "10.0.0.0/16"
@@ -9,30 +10,26 @@ module "vpc" {
 }
 
 module "eks_cluster" {
-  source = "cloudposse/eks-cluster/aws"
+  source  = "cloudposse/eks-cluster/aws"
+  version = "0.43.2"
 
   region     = "eu-central-1"
   subnet_ids = module.vpc.public_subnets
   vpc_id     = module.vpc.vpc_id
   name       = "cluster-autoscaler"
-
-  workers_security_group_ids = [module.eks_workers.security_group_id]
-  workers_role_arns          = [module.eks_workers.workers_role_arn]
 }
 
-module "eks_workers" {
-  source = "cloudposse/eks-workers/aws"
+module "eks_node_group" {
+  source  = "cloudposse/eks-node-group/aws"
+  version = "0.25.0"
 
-  cluster_certificate_authority_data = module.eks_cluster.eks_cluster_certificate_authority_data
-  cluster_endpoint                   = module.eks_cluster.eks_cluster_endpoint
-  cluster_name                       = "cluster-autoscaler"
-  instance_type                      = "t3.medium"
-  max_size                           = 1
-  min_size                           = 1
-  subnet_ids                         = module.vpc.public_subnets
-  vpc_id                             = module.vpc.vpc_id
-
-  associate_public_ip_address = true
+  cluster_name   = "cluster-autoscaler"
+  instance_types = ["t3.medium"]
+  subnet_ids     = module.vpc.public_subnets
+  min_size       = 1
+  desired_size   = 1
+  max_size       = 2
+  depends_on     = [module.eks_cluster.kubernetes_config_map_id]
 }
 
 module "cluster_autoscaler" {

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -25,8 +25,8 @@ module "eks_workers" {
 
   cluster_certificate_authority_data = module.eks_cluster.eks_cluster_certificate_authority_data
   cluster_endpoint                   = module.eks_cluster.eks_cluster_endpoint
-  cluster_name                       = module.eks_cluster.eks_cluster_id
-  cluster_security_group_id          = module.eks_cluster.security_group_id
+  cluster_name                       = "cluster-autoscaler"
+#  cluster_security_group_id          = module.eks_cluster.security_group_id
   instance_type                      = "t3.medium"
   max_size                           = 1
   min_size                           = 1
@@ -35,8 +35,6 @@ module "eks_workers" {
 
   associate_public_ip_address = true
 }
-
-# Use the module:
 
 module "cluster_autoscaler" {
   source = "../../"

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -26,7 +26,6 @@ module "eks_workers" {
   cluster_certificate_authority_data = module.eks_cluster.eks_cluster_certificate_authority_data
   cluster_endpoint                   = module.eks_cluster.eks_cluster_endpoint
   cluster_name                       = "cluster-autoscaler"
-#  cluster_security_group_id          = module.eks_cluster.security_group_id
   instance_type                      = "t3.medium"
   max_size                           = 1
   min_size                           = 1

--- a/examples/basic/providers.tf
+++ b/examples/basic/providers.tf
@@ -10,12 +10,6 @@ data "aws_eks_cluster_auth" "this" {
   name = module.eks_cluster.eks_cluster_id
 }
 
-provider "kubernetes" {
-  host                   = data.aws_eks_cluster.this.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority.0.data)
-  token                  = data.aws_eks_cluster_auth.this.token
-}
-
 provider "helm" {
   kubernetes {
     host                   = data.aws_eks_cluster.this.endpoint

--- a/iam.tf
+++ b/iam.tf
@@ -32,7 +32,6 @@ resource "aws_iam_policy" "cluster_autoscaler" {
   policy = data.aws_iam_policy_document.cluster_autoscaler[0].json
 }
 
-# Role
 data "aws_iam_policy_document" "cluster_autoscaler_assume" {
   count = var.enabled ? 1 : 0
 

--- a/iam.tf
+++ b/iam.tf
@@ -1,14 +1,3 @@
-resource "kubernetes_namespace" "cluster_autoscaler" {
-  depends_on = [var.mod_dependency]
-  count      = (var.enabled && var.k8s_namespace != "kube-system") ? 1 : 0
-
-  metadata {
-    name = var.k8s_namespace
-  }
-}
-
-### iam ###
-# Policy
 data "aws_iam_policy_document" "cluster_autoscaler" {
   count = var.enabled ? 1 : 0
 

--- a/iam.tf
+++ b/iam.tf
@@ -1,5 +1,5 @@
 data "aws_iam_policy_document" "cluster_autoscaler" {
-  count = var.enabled ? 1 : 0
+  count = local.k8s_irsa_role_create ? 1 : 0
 
   statement {
     sid = "Autoscaling"
@@ -24,7 +24,7 @@ data "aws_iam_policy_document" "cluster_autoscaler" {
 }
 
 resource "aws_iam_policy" "cluster_autoscaler" {
-  count       = var.enabled ? 1 : 0
+  count       = local.k8s_irsa_role_create ? 1 : 0
   name        = "${var.cluster_name}-cluster-autoscaler"
   path        = "/"
   description = "Policy for cluster-autoscaler service"
@@ -33,7 +33,7 @@ resource "aws_iam_policy" "cluster_autoscaler" {
 }
 
 data "aws_iam_policy_document" "cluster_autoscaler_assume" {
-  count = var.enabled ? 1 : 0
+  count = local.k8s_irsa_role_create ? 1 : 0
 
   statement {
     actions = ["sts:AssumeRoleWithWebIdentity"]
@@ -57,13 +57,13 @@ data "aws_iam_policy_document" "cluster_autoscaler_assume" {
 }
 
 resource "aws_iam_role" "cluster_autoscaler" {
-  count              = var.enabled ? 1 : 0
+  count              = local.k8s_irsa_role_create ? 1 : 0
   name               = "${var.cluster_name}-cluster-autoscaler"
   assume_role_policy = data.aws_iam_policy_document.cluster_autoscaler_assume[0].json
 }
 
 resource "aws_iam_role_policy_attachment" "cluster_autoscaler" {
-  count      = var.enabled ? 1 : 0
+  count      = local.k8s_irsa_role_create ? 1 : 0
   role       = aws_iam_role.cluster_autoscaler[0].name
   policy_arn = aws_iam_policy.cluster_autoscaler[0].arn
 }

--- a/iam.tf
+++ b/iam.tf
@@ -24,7 +24,6 @@ data "aws_iam_policy_document" "cluster_autoscaler" {
 }
 
 resource "aws_iam_policy" "cluster_autoscaler" {
-  depends_on  = [var.mod_dependency]
   count       = var.enabled ? 1 : 0
   name        = "${var.cluster_name}-cluster-autoscaler"
   path        = "/"
@@ -59,14 +58,12 @@ data "aws_iam_policy_document" "cluster_autoscaler_assume" {
 }
 
 resource "aws_iam_role" "cluster_autoscaler" {
-  depends_on         = [var.mod_dependency]
   count              = var.enabled ? 1 : 0
   name               = "${var.cluster_name}-cluster-autoscaler"
   assume_role_policy = data.aws_iam_policy_document.cluster_autoscaler_assume[0].json
 }
 
 resource "aws_iam_role_policy_attachment" "cluster_autoscaler" {
-  depends_on = [var.mod_dependency]
   count      = var.enabled ? 1 : 0
   role       = aws_iam_role.cluster_autoscaler[0].name
   policy_arn = aws_iam_policy.cluster_autoscaler[0].arn

--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,5 @@
-data "aws_region" "current" {}
-
-resource "helm_release" "cluster_autoscaler" {
-  depends_on = [var.mod_dependency]
-  count      = var.enabled ? 1 : 0
-  chart      = var.helm_chart_name
-  namespace  = var.k8s_namespace
-  name       = var.helm_release_name
-  version    = var.helm_chart_version
-  repository = var.helm_repo_url
-
-  values = [
-    yamlencode({
+locals {
+  values = yamlencode({
       "awsRegion" : data.aws_region.current.name,
       "autoDiscovery" : {
         "clusterName" : var.cluster_name
@@ -25,8 +14,30 @@ resource "helm_release" "cluster_autoscaler" {
           }
         }
       }
-    }),
-  var.values]
+    })
+}
+
+data "aws_region" "current" {}
+
+data "utils_deep_merge_yaml" "values" {
+  count      = var.enabled ? 1 : 0
+  input      = compact([
+    local.values,
+    var.values
+  ])
+}
+
+resource "helm_release" "cluster_autoscaler" {
+  count            = var.enabled ? 1 : 0
+  chart            = var.helm_chart_name
+  namespace        = var.k8s_namespace
+  name             = var.helm_release_name
+  version          = var.helm_chart_version
+  repository       = var.helm_repo_url
+
+  values = [
+    data.utils_deep_merge_yaml.values[0].output
+  ]
 
   dynamic "set" {
     for_each = var.settings

--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,7 @@ data "utils_deep_merge_yaml" "values" {
 resource "helm_release" "cluster_autoscaler" {
   count            = var.enabled ? 1 : 0
   chart            = var.helm_chart_name
+  create_namespace = var.helm_create_namespace
   namespace        = var.k8s_namespace
   name             = var.helm_release_name
   version          = var.helm_chart_version

--- a/main.tf
+++ b/main.tf
@@ -1,27 +1,27 @@
 locals {
   values = yamlencode({
-      "awsRegion" : data.aws_region.current.name,
-      "autoDiscovery" : {
-        "clusterName" : var.cluster_name
-      },
-      "rbac" : {
+    "awsRegion" : data.aws_region.current.name,
+    "autoDiscovery" : {
+      "clusterName" : var.cluster_name
+    },
+    "rbac" : {
+      "create" : true,
+      "serviceAccount" : {
         "create" : true,
-        "serviceAccount" : {
-          "create" : true,
-          "name" : var.k8s_service_account_name
-          "annotations" : {
-            "eks.amazonaws.com/role-arn" : var.enabled ? aws_iam_role.cluster_autoscaler[0].arn : ""
-          }
+        "name" : var.k8s_service_account_name
+        "annotations" : {
+          "eks.amazonaws.com/role-arn" : var.enabled ? aws_iam_role.cluster_autoscaler[0].arn : ""
         }
       }
-    })
+    }
+  })
 }
 
 data "aws_region" "current" {}
 
 data "utils_deep_merge_yaml" "values" {
-  count      = var.enabled ? 1 : 0
-  input      = compact([
+  count = var.enabled ? 1 : 0
+  input = compact([
     local.values,
     var.values
   ])

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ locals {
           "create" : true,
           "name" : var.k8s_service_account_name
           "annotations" : {
-            "eks.amazonaws.com/role-arn" : aws_iam_role.cluster_autoscaler[0].arn
+            "eks.amazonaws.com/role-arn" : var.enabled ? aws_iam_role.cluster_autoscaler[0].arn : ""
           }
         }
       }

--- a/main.tf
+++ b/main.tf
@@ -5,9 +5,9 @@ locals {
       "clusterName" : var.cluster_name
     },
     "rbac" : {
-      "create" : true,
+      "create" : var.k8s_rbac_create,
       "serviceAccount" : {
-        "create" : true,
+        "create" : var.k8s_service_account_create,
         "name" : var.k8s_service_account_name
         "annotations" : {
           "eks.amazonaws.com/role-arn" : var.enabled ? aws_iam_role.cluster_autoscaler[0].arn : ""

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,6 @@
 locals {
+  k8s_irsa_role_create = var.enabled && var.k8s_rbac_create && var.k8s_service_account_create && var.k8s_irsa_role_create
+
   values = yamlencode({
     "awsRegion" : data.aws_region.current.name,
     "autoDiscovery" : {
@@ -10,7 +12,7 @@ locals {
         "create" : var.k8s_service_account_create,
         "name" : var.k8s_service_account_name
         "annotations" : {
-          "eks.amazonaws.com/role-arn" : var.enabled ? aws_iam_role.cluster_autoscaler[0].arn : ""
+          "eks.amazonaws.com/role-arn" : local.k8s_irsa_role_create ? aws_iam_role.cluster_autoscaler[0].arn : ""
         }
       }
     }

--- a/variables.tf
+++ b/variables.tf
@@ -65,12 +65,6 @@ variable "k8s_service_account_name" {
   description = "The k8s cluster-autoscaler service account name"
 }
 
-variable "mod_dependency" {
-  type        = bool
-  default     = null
-  description = "Dependence variable binds all AWS resources allocated by this module, dependent modules reference this variable"
-}
-
 variable "settings" {
   type        = map(any)
   default     = {}

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,7 @@ variable "helm_chart_name" {
 
 variable "helm_chart_version" {
   type        = string
-  default     = "9.7.0"
+  default     = "9.10.3"
   description = "Version of the Helm chart"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -42,14 +42,17 @@ variable "helm_release_name" {
   default     = "cluster-autoscaler"
   description = "Helm release name"
 }
-
 variable "helm_repo_url" {
   type        = string
   default     = "https://kubernetes.github.io/autoscaler"
   description = "Helm repository"
 }
 
-# K8s
+variable "helm_create_namespace" {
+  type        = bool
+  default     = true
+  description = "Create the namespace if it does not yet exist"
+}
 
 variable "k8s_namespace" {
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,8 @@
-# Required module inputs
+variable "enabled" {
+  type        = bool
+  default     = true
+  description = "Variable indicating whether deployment is enabled"
+}
 
 variable "cluster_name" {
   type        = string
@@ -14,16 +18,6 @@ variable "cluster_identity_oidc_issuer_arn" {
   type        = string
   description = "The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account"
 }
-
-# cluster-autoscaler
-
-variable "enabled" {
-  type        = bool
-  default     = true
-  description = "Variable indicating whether deployment is enabled"
-}
-
-# Helm
 
 variable "helm_chart_name" {
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,19 @@ variable "k8s_namespace" {
   description = "The K8s namespace in which the node-problem-detector service account has been created"
 }
 
+variable "k8s_rbac_create" {
+  type        = bool
+  default     = true
+  description = "Whether to create and use RBAC resources"
+}
+
+variable "k8s_service_account_create" {
+  type        = bool
+  default     = true
+  description = "Whether to create Service Account"
+}
+
+
 variable "k8s_service_account_name" {
   default     = "cluster-autoscaler"
   description = "The k8s cluster-autoscaler service account name"

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,11 @@ variable "k8s_service_account_create" {
   description = "Whether to create Service Account"
 }
 
+variable "k8s_irsa_role_create" {
+  type        = bool
+  default     = true
+  description = "Whether to create IRSA role and annotate service account"
+}
 
 variable "k8s_service_account_name" {
   default     = "cluster-autoscaler"

--- a/versions.tf
+++ b/versions.tf
@@ -10,9 +10,9 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 1.0"
     }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 1.10"
+    utils = {
+      source = "cloudposse/utils"
+      version = ">= 0.12.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -11,7 +11,7 @@ terraform {
       version = ">= 1.0"
     }
     utils = {
-      source = "cloudposse/utils"
+      source  = "cloudposse/utils"
       version = ">= 0.12.0"
     }
   }


### PR DESCRIPTION
Changes:
* Add ability to override or add configuration options in default values 
* Delegate Kubernetes namespace creation to helm provider from Kubernetes provider
* Remove fake dependency variable in favor of terraform built-in module dependency
* Bump default chart version to the 9.10.3 

Fix:
* Namespace race condition https://github.com/lablabs/terraform-aws-eks-cluster-autoscaler/issues/5

Breaking changes:
* Removes fake dependency variable `mod_dependency` in favor of terraform built-in module dependency injection