### PR TITLE
feat: add DescribeNodegroup action to iam policy

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -16,7 +16,8 @@ data "aws_iam_policy_document" "this" {
       "autoscaling:SetDesiredCapacity",
       "autoscaling:TerminateInstanceInAutoScalingGroup",
       "ec2:DescribeLaunchTemplateVersions",
-      "ec2:DescribeInstanceTypes"
+      "ec2:DescribeInstanceTypes",
+      "eks:DescribeNodegroup"
     ]
 
     resources = [


### PR DESCRIPTION
# Description

add `eks:DescribeNodegroup` action to iam policy to make scaling from (to) zero work
available in EKS from version 1.24

[Autoscaling | AWS docs](https://docs.aws.amazon.com/eks/latest/userguide/autoscaling.html)

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

run terraform plan and apply
