### PR TITLE
fix: AlreadyExists Error

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -47,7 +47,7 @@ data "aws_iam_policy_document" "this_assume" {
 resource "aws_iam_policy" "this" {
   count = local.irsa_role_create && (var.irsa_policy_enabled || var.irsa_assume_role_enabled) ? 1 : 0
 
-  name        = "${var.irsa_role_name_prefix}-${var.helm_chart_name}"
+  name        = "${var.cluster_name}-${var.irsa_role_name_prefix}-${var.helm_chart_name}"
   path        = "/"
   description = "Policy for cluster-autoscaler service"
   policy      = var.irsa_assume_role_enabled ? data.aws_iam_policy_document.this_assume[0].json : data.aws_iam_policy_document.this[0].json
@@ -81,7 +81,7 @@ data "aws_iam_policy_document" "this_irsa" {
 
 resource "aws_iam_role" "this" {
   count              = local.irsa_role_create ? 1 : 0
-  name               = "${var.irsa_role_name_prefix}-${var.helm_chart_name}"
+  name               = "${var.cluster_name}-${var.irsa_role_name_prefix}-${var.helm_chart_name}"
   assume_role_policy = data.aws_iam_policy_document.this_irsa[0].json
   tags               = var.irsa_tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -97,7 +97,7 @@ variable "irsa_additional_policies" {
 
 variable "irsa_role_name_prefix" {
   type        = string
-  default     = "cluster-autoscaler-irsa"
+  default     = "irsa"
   description = "The IRSA role name prefix for vector"
 }
 


### PR DESCRIPTION
## fixing AlreadyExists error for aws_iam_role / aws_iam_policy

updating the name of the role and policy -->
prefixing the cluster name will make the role/policy to be unique for each of  the cluster.

# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes.
-->
