### PR TITLE
fix: update helm version constraint to restrict to ~> 2.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See [basic example](examples/basic) for further information.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.6.0, < 3.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.6.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.20.0 |
 | <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.17.0 |
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See [basic example](examples/basic) for further information.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.6.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.6.0, < 3.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.20.0 |
 | <a name="requirement_utils"></a> [utils](#requirement\_utils) | >= 0.17.0 |
 

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.6.0"
+      version = ">= 2.6.0, < 3.0"
     }
   }
 }

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.6.0, < 3.0"
+      version = "~> 2.6.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -13,7 +13,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.6.0"
+      version = ">= 2.6.0, < 3.0"
     }
     utils = {
       source  = "cloudposse/utils"

--- a/versions.tf
+++ b/versions.tf
@@ -13,7 +13,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.6.0, < 3.0"
+      version = "~> 2.6.0"
     }
     utils = {
       source  = "cloudposse/utils"


### PR DESCRIPTION
# What does this PR do?
Pin Helm provider max supported version due to new major provider version breaking changes

# Motivation
Recent Helm v3.x introduces breaking changes, theres already a hotfix out https://github.com/hashicorp/terraform-provider-helm/releases. Supporting v3.x would require breaking changes to this module so for now, pinning should suffice


## Type of change

- [*] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

Inspired by this PR https://github.com/aws-ia/terraform-aws-eks-blueprints-addons/pull/453